### PR TITLE
Fix code scanning alert no. 2: Reflected cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.21.1"
+    "express": "^4.21.1",
+    "escape-html": "^1.0.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const app = express();
 const cors = require('cors')
+const escape = require('escape-html');
 app.use(cors());
 
 let texto = "";
@@ -11,13 +12,13 @@ app.get('/', (req, res) => {
 });
 
 app.get('/grab', (req,res) => {
-    const data = req.query.data;
+    const data = escape(req.query.data);
     texto += data;
     res.send(data);
 })
 
 app.get('/read', (req,res) => {
-    res.send(texto);
+    res.send(escape(texto));
 })
 
 


### PR DESCRIPTION
Fixes [https://github.com/Cristian727/datagrab/security/code-scanning/2](https://github.com/Cristian727/datagrab/security/code-scanning/2)

To fix the problem, we need to sanitize the user input before appending it to the `texto` variable and before sending it back in the response. This can be done using a library like `escape-html` to escape any potentially harmful characters in the user input.

1. Install the `escape-html` library.
2. Import the `escape-html` library in the `server.js` file.
3. Use the `escape` function from the `escape-html` library to sanitize the `data` parameter before appending it to `texto` and before sending it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
